### PR TITLE
Class WebScraper now uses class Retailer

### DIFF
--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -25,9 +25,12 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         }
 
         private ButtonManager nfButtonManager;
-        HttpClient client = new HttpClient();
-        ApiKey key = new ApiKey();
-        WebView webView = new WebView();
+        private HttpClient client = new HttpClient();
+        private ApiKey key = new ApiKey();
+        private WebView webView = new WebView();
+        private Retailer walmart = new Retailer();
+        private Retailer target = new Retailer();
+        private Retailer cvs = new Retailer();
 
         private string url;
         private string walmartUrl = "http://api.walmartlabs.com/v1/items";
@@ -109,11 +112,25 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             return roundedValue - 0.01;
         }
 
+        private void InitializeRetailers()
+        {
+            walmart.WebsiteURL = "http://api.walmartlabs.com/v1/items";
+            walmart.Name = "Walmart";
+            walmart.OnlineAbbrev = "WM";
+
+            target.WebsiteURL = "https://www.target.com/s?searchTerm=";
+            target.Name = "Target";
+            target.OnlineAbbrev = "TG";
+
+            cvs.WebsiteURL = "https://www.cvs.com/search?searchTerm=";
+            cvs.Name = "CVS";
+            cvs.OnlineAbbrev = "CVS";
+        }
+
         public async void UPCSearch(object sender, KeyRoutedEventArgs e)
         {
             if (e.Key == Windows.System.VirtualKey.Enter)
             {
-
                 // search Walmart
                 try
                 {

--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -37,7 +37,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         private double onlinePrice;
         private string upc;
         private string textblockPrice;
-        private bool walmartInformation;
         private bool targetInformation;
         private string onlineAbbrev;
 
@@ -50,12 +49,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         {
             get { return found; }
             set { found = value; }
-        }
-
-        public bool WalmartInformation
-        {
-            get { return walmartInformation; }
-            set { walmartInformation = value; }
         }
         public bool TargetInformation
         {
@@ -204,10 +197,10 @@ namespace AddInCalculator2._0.Models.AddInCalculator
                         double priceHolder;
                         if (Double.TryParse(jsonString, out priceHolder))
                         {
-                            OnlinePrice = priceHolder;
+                            walmart.OnlinePrice = priceHolder;
                         }
 
-                        bool walmartFound = false;
+                        bool walmartFound = false, walmartInformation = false;
                         int i = 0;
                         // still need to traverse the collection to get correct percentage in case it changes in future
                         for (i = 0; (i < NFButtonManager.nfCollection.Count() && (walmartFound == false)); ++i)
@@ -216,11 +209,11 @@ namespace AddInCalculator2._0.Models.AddInCalculator
                             if (NFButtonManager.nfCollection[i].retailer == "Walmart")
                             {
                                 walmartFound = true;
-                                WalmartInformation = true;
+                                walmartInformation = true;
                             }
                         }
 
-                        if (WalmartInformation)
+                        if (walmartInformation)
                         {
                             OnlineAbbrev = (" @WM $" + OnlinePrice.ToString());
                             OnlinePrice *= (NFButtonManager.nfCollection[i - 1].percentage / 100);
@@ -230,7 +223,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
                         {
                             var messageDialog = new MessageDialog("No Walmart information was found in the calculator");
                             await messageDialog.ShowAsync();
-                            WalmartInformation = false;
                         }
                     }
                     else

--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -36,9 +36,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         private bool found;
         private string onlinePrice;
         private string upc;
-        private string textblockPrice;
-        private bool targetInformation;
-        private string onlineAbbrev;
 
         public ButtonManager NFButtonManager
         {
@@ -50,16 +47,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             get { return found; }
             set { found = value; }
         }
-        public bool TargetInformation
-        {
-            get { return targetInformation; }
-            set { targetInformation = value; }
-        }
-        public string OnlineAbbrev
-        {
-            get { return onlineAbbrev; }
-            set { onlineAbbrev = value; }
-        }
         public string UPC
         {
             get { return upc; }
@@ -67,15 +54,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             {
                 upc = value;
                 OnPropertyChanged("UPC");
-            }
-        }
-        public string TextblockPrice
-        {
-            get { return textblockPrice; }
-            set
-            {
-                textblockPrice = value;
-                OnPropertyChanged("TextblockPrice");
             }
         }
         public string OnlinePrice

--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -28,11 +28,11 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         private HttpClient client = new HttpClient();
         private ApiKey key = new ApiKey();
         private WebView webView = new WebView();
+
         private Retailer walmart = new Retailer();
         private Retailer target = new Retailer();
         private Retailer cvs = new Retailer();
 
-        private string walmartUrl = "http://api.walmartlabs.com/v1/items";
         private bool found;
         private double onlinePrice;
         private string upc;
@@ -45,11 +45,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         {
             get { return nfButtonManager; }
             set { }
-        }
-        public string WalmartUrl
-        {
-            get { return walmartUrl; }
-            set { walmartUrl = "http://api.walmartlabs.com/v1/items" + key.WalmartKey; }
         }
         public bool Found
         {
@@ -190,7 +185,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         {
             try
             {
-                var url = (WalmartUrl + key.WalmartKey + UPC);
+                var url = (walmart.WebsiteURL + key.WalmartKey + UPC);
                 var walmartResponse = await client.GetAsync(new Uri(url));
                 walmartResponse.EnsureSuccessStatusCode();
 

--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -32,7 +32,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         private Retailer target = new Retailer();
         private Retailer cvs = new Retailer();
 
-        private string url;
         private string walmartUrl = "http://api.walmartlabs.com/v1/items";
         private bool found;
         private double onlinePrice;
@@ -46,11 +45,6 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         {
             get { return nfButtonManager; }
             set { }
-        }
-        public string URL
-        {
-            get { return url; }
-            set { url = value; }
         }
         public string WalmartUrl
         {
@@ -196,7 +190,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         {
             try
             {
-                url = (WalmartUrl + key.WalmartKey + UPC);
+                var url = (WalmartUrl + key.WalmartKey + UPC);
                 var walmartResponse = await client.GetAsync(new Uri(url));
                 walmartResponse.EnsureSuccessStatusCode();
 
@@ -268,7 +262,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             try
             {
                 string targetURL = "https://www.target.com/s?searchTerm=";
-                url = (targetURL + UPC);
+                var url = (targetURL + UPC);
 
 
                 webView.Navigate(new Uri(url));
@@ -304,7 +298,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             try
             {
                 string cvsURL = "https://www.cvs.com/search?searchTerm=";
-                url = (cvsURL + UPC);
+                var url = (cvsURL + UPC);
 
                 webView.Navigate(new Uri(url));
                 await Task.Delay(10000);

--- a/Models/AddInCalculator/WebScraper.cs
+++ b/Models/AddInCalculator/WebScraper.cs
@@ -34,7 +34,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
         private Retailer cvs = new Retailer();
 
         private bool found;
-        private double onlinePrice;
+        private string onlinePrice;
         private string upc;
         private string textblockPrice;
         private bool targetInformation;
@@ -78,7 +78,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
                 OnPropertyChanged("TextblockPrice");
             }
         }
-        public double OnlinePrice
+        public string OnlinePrice
         {
             get { return onlinePrice; }
             set
@@ -111,6 +111,8 @@ namespace AddInCalculator2._0.Models.AddInCalculator
 
         public async void UPCSearch(object sender, KeyRoutedEventArgs e)
         {
+            InitializeRetailers();
+
             if (e.Key == Windows.System.VirtualKey.Enter)
             {
                 // search Walmart
@@ -158,13 +160,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
                     Debug.WriteLine("Exception caught.");
                     Debug.WriteLine(exception);
                 }*/
-
-                // if a price was found
-                if (Found)
-                {
-                    TextblockPrice = OnlinePrice.ToString() + onlineAbbrev;
-                }
-                else
+                if (!Found)
                 {
                     var messageDialog = new MessageDialog("No price was found online.");
                     await messageDialog.ShowAsync();
@@ -180,6 +176,7 @@ namespace AddInCalculator2._0.Models.AddInCalculator
             {
                 var url = (walmart.WebsiteURL + key.WalmartKey + UPC);
                 var walmartResponse = await client.GetAsync(new Uri(url));
+                
                 walmartResponse.EnsureSuccessStatusCode();
 
                 if (walmartResponse.IsSuccessStatusCode)
@@ -215,9 +212,9 @@ namespace AddInCalculator2._0.Models.AddInCalculator
 
                         if (walmartInformation)
                         {
-                            OnlineAbbrev = (" @WM $" + OnlinePrice.ToString());
-                            OnlinePrice *= (NFButtonManager.nfCollection[i - 1].percentage / 100);
-                            OnlinePrice = RoundToNine(OnlinePrice);
+                            walmart.OnlinePrice *= (NFButtonManager.nfCollection[i - 1].percentage / 100);
+                            walmart.OnlinePrice = RoundToNine(walmart.OnlinePrice);
+                            OnlinePrice = "@ " + walmart.OnlineAbbrev + " $" + walmart.OnlinePrice.ToString();
                         }
                         else
                         {

--- a/Views/NFCalculator.xaml
+++ b/Views/NFCalculator.xaml
@@ -172,7 +172,7 @@
             <StackPanel>
                 <StackPanel Orientation="Horizontal">
                     <TextBox Width="250" HorizontalAlignment="Left" KeyDown="{x:Bind nfViewModel.Scraper.UPCSearch}" Name="UPCTextBox" Text="{Binding Scraper.UPC, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                    <TextBlock Width="150" Margin="100,0,0,0" Text="{Binding Scraper.TextblockPrice, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Name="onlinePrice"/>
+                    <TextBlock Width="150" Margin="100,0,0,0" Text="{Binding Scraper.OnlinePrice, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Name="onlinePrice"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
                     <Button Name="Button1" Content="{Binding NFButtonManager.nfCollection[0].retailer}" Style="{StaticResource NFRegStyle1}" Margin="0,0,5,5" FontSize="12" Click="{x:Bind nfViewModel.Calculator.WebsiteClick}" Visibility="{Binding NFButtonManager.nfCollection[0].visibility, Converter={StaticResource boolToVisibilityConverter}}"/>


### PR DESCRIPTION
Although WebScraper now uses Retailer, it really shouldn't need to.

The current database uses a Button object, however the Button object doesn't have a Retailer object. If Button class included a Retailer object, then the database could have a function that returns the retailer object, which could be used for searching the websites, instead of having to create Retailer objects.

 I'm not sure this is the best design, but the Button class should have a Retailer object. If it did, the implementation for searching websites would be different. It could iterate through each Retailer from a list returned by the database, and search each Retailer's Retailer::WebsiteURL.

Additionally, class Retailer does not have a APIKey object due to security. If I refactor the class to have a APIKey object, then I have to work around that censorship when committing changes.